### PR TITLE
feat: support async JS execution and ESM modules

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -36,10 +36,10 @@ type IFrameWorkerOptions = WorkerOptions & {
  * This `WebWorker` shim is implemented on top of an `IFrameElement` to allow
  * workers in contexts when `XMLHTTPRequest` is not available, or blocked by the
  * browser, e.g. when using the `file://` protocol. This shim can provide
- * asynchronous workers, if the options.src property is defined, it's origin is
- * different than that of the parent window's origin, or if
- * the Origin-Agent-Cluster header is used by the underlying HTTP server,
- * otherwise the script is executed synchronously.
+ * asynchronous workers, if the url property is an HTML file which imports the
+ * setup script, it's origin is different than that of the parent window's
+ * origin, or if the Origin-Agent-Cluster header is used by the underlying HTTP
+ * server, otherwise the script is executed synchronously.
  */
 export class IFrameWorker extends EventTarget implements Worker {
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -22,6 +22,11 @@
 
 import { importScripts, postMessage } from "./runtime"
 
+type IFrameWorkerOptions = WorkerOptions & {
+  src?: string
+  credentials?: ReferrerPolicy
+}
+
 /* ----------------------------------------------------------------------------
  * Class
  * ------------------------------------------------------------------------- */
@@ -64,7 +69,7 @@ export class IFrameWorker extends EventTarget implements Worker {
    * @param options - Worker script options
    * @param options.src - IFrame src url
    */
-  public constructor(protected url: string, { credentials, type, src }: WorkerOptions = {}) {
+  public constructor(protected url: string, { credentials, type, src }: IFrameWorkerOptions = {}) {
     super()
 
     /* Create iframe to host the worker script */


### PR DESCRIPTION
this implements what #522 wanted.

I'm not certain the `referrerPolicy` is required, but I added it regardless.

Additionally added support for ESM modules because ESM is cool.

General idea is that the entire script would be loaded from some CDN, this would mean it runs in a different origin than the website's main script, which would *hopefully* allow the worker to run async, this functionality is simply for browsers that don't support the `Origin-Agent-Cluster` header, so this would look something like:
```js
import IFrameWorker from 'https://esm.sh/iframe-worker'

const worker = new IFrameWorker('https://absolutedomain.com/myscript.js', { url: 'https://esm.sh/404', type: 'module' })
```
and if the `Origin-Agent-Cluster` is supported, re: we're only targetting chrome simply
```js
import IFrameWorker from 'iframe-worker'

const worker = new IFrameWorker('./myscript.js', { url: './404', type: 'module' })
```
would be enough



haven't actually tested it, this is just purely an idea from reading specifications x)